### PR TITLE
Fix sample prediction break

### DIFF
--- a/pkg/Cubist/R/predict.cubist.R
+++ b/pkg/Cubist/R/predict.cubist.R
@@ -26,11 +26,14 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...)
   ## make cases file
   caseString <- makeDataFile(x = newdata, y = NULL)
   
+  ## fix breaking predictions when using sample parameter
+  caseModel <- ifelse(!(regexpr("sample", object$model) == -1), paste(substr(object$model, 1, regexpr("sample", object$model)-1), substr(object$model, regexpr("entries", object$model), nchar(object$model)), sep = ""), object$model)
+  
   Z <- .C("predictions",
           as.character(caseString),
           as.character(object$names),
           as.character(object$data),
-          as.character(object$model),
+          as.character(caseModel),
           pred = double(nrow(newdata)),    
           output = character(1),
           PACKAGE = "Cubist"


### PR DESCRIPTION
Fixing the following reported issue: predict.cubist unable to predict properly using sample (cubistControl) #1

tl;dr explanation: when using sample parameter in cubistControl, predictions are breaking down immediately (unable to predict properly, non-sensical predictions with large error, near zero correlation, etc.). This fix solves this issue without creating other issues.

Extra explanation about the fix:

There is probably a proper way to do it using a better regex but this version works perfectly, whether there is sample defined or not. Init has no impact overall.

It removes everything starting from "sample" and before "entries".

I found no impact removing redn (it shows up between sample and entries when using commitees).
redn = final error / (sum of errors / (number of commitees - 1)), just a calculated output value (it happens to be read when fed into Cubist into ErrReduction variable, but is not used at all to predict).
