### PR TITLE
Gcc10

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^README.md$
 ^revdep$
 .DS_Store
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ config.status
 revdep/*.noindex
 .DS_Store
 revdep/data.sqlite
+.Rproj.user

--- a/Cubist.Rproj
+++ b/Cubist.Rproj
@@ -1,0 +1,19 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Cubist
 Type: Package
 Title: Rule- And Instance-Based Regression Modeling
-Version: 0.2.2
+Version: 0.2.2.9000
 Authors@R: c(
     person("Max", "Kuhn", , "mxkuhn@gmail.com", c("aut", "cre")),
     person("Steve", "Weston", role = "ctb"),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,12 @@
 \newcommand{\cpkg}{\href{https://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \newcommand{\issue}{\href{https://github.com/topepo/cubist/issues/#1}{(issue #1)}}
 
+\section{Changes in the development version}{
+\itemize{
+\item Maintenance release to fix CRAN issues for GCC 10 -fno-common flag.
+ }  
+}
+
 \section{Changes in version 0.2.2}{
 \itemize{ 
 \item Maintenance release to fix CRAN issues for C string buffers

--- a/src/extern.h
+++ b/src/extern.h
@@ -61,7 +61,7 @@ extern ContValue *AttMean, *AttSD, *AttMaxVal, *AttMinVal, *AttPref, Ceiling,
 
 extern float ErrReduction;
 
-double *AttUnit;
+extern double *AttUnit;
 
 extern int *AttPrec;
 


### PR DESCRIPTION
Fixes the failures detected by the gcc10 build on CRAN
https://www.stats.ox.ac.uk/pub/bdr/gcc10/Cubist.log

The specific problem doesn't have anything to do with the warnings that get emitted along the way, but instead happens at link time.

The relevant section is this final linking step:

```
/usr/local/gcc10/bin/gcc -shared -L/usr/local/gcc10/lib64 -L/usr/local/lib64 -o Cubist.so construct.o contin.o discr.o formrules.o formtree.o getdata.o getnames.o global.o hash.o implicitatt.o instance.o modelfiles.o predict.o prunetree.o rcubist.o redefine.o regress.o rsample.o rulebasedmodels.o rules.o sample.o sort.o stats.o strbuf.o top.o trees.o update.o utility.o xval.o
/usr/bin/ld: contin.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: discr.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: formrules.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: formtree.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: getdata.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: getnames.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: global.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/global.c:87: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: implicitatt.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: instance.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: modelfiles.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: predict.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: prunetree.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: rcubist.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: regress.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: rsample.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: rulebasedmodels.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: rules.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: sample.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: sort.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: stats.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: trees.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: update.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: utility.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
/usr/bin/ld: xval.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: multiple definition of `AttUnit'; construct.o:/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src/extern.h:64: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [/data/gannet/ripley/R/R-gcc10/share/make/shlib.mk:6: Cubist.so] Error 1
make[1]: Target 'all' not remade because of errors.
make[1]: Leaving directory '/data/gannet/ripley/R/packages/tests-gcc10/Cubist/src'
ERROR: compilation failed for package ‘Cubist’
* removing ‘/data/gannet/ripley/R/packages/tests-gcc10/Cubist.Rcheck/Cubist’
```

With the main line that helped me being:

```
multiple definition of `AttUnit'
```

This is the same problem as described by Lionel in vctrs here:
https://github.com/r-lib/vctrs/commit/594c595e3a6425fe53a88f6e563d0b1c3d9491d3

Which he originally found from this, which reports that `fno-common` is the default in GCC 10 now.
https://github.com/Ettercap/ettercap/issues/795#issuecomment-561168625

> From https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html:
>    -fcommon
>
>    In C code, this option controls the placement of global variables defined without an initializer, known as tentative definitions in the C standard. Tentative definitions are distinct from declarations of a variable with the extern keyword, which do not allocate storage.
>
>    The default is -fno-common, which specifies that the compiler places uninitialized global variables in the BSS section of the object file. This inhibits the merging of tentative definitions by the linker so you get a multiple-definition error if the same variable is accidentally defined in more than one compilation unit.

We just need to add an `extern` to get rid of the error (hopefully). There will still be a number of warnings, but hopefully CRAN is still okay with them