### PR TITLE
Missing column names

### DIFF
--- a/R/cubist.R
+++ b/R/cubist.R
@@ -174,6 +174,7 @@ cubist.default <- function(x, y,
   if (!is.null(weights) && !is.numeric(weights))
     stop("case weights must be numeric", call. = FALSE)
 
+  check_names(x)
   namesString <-
     makeNamesFile(x, y, w = weights, label = control$label, comments = TRUE)
   dataString <- makeDataFile(x, y, weights)
@@ -224,7 +225,9 @@ cubist.default <- function(x, y,
 
   usage <- varUsage(Z$output)
   if (is.null(usage) || nrow(usage) < ncol(x)) {
+    check_names(x)
     xNames <- colnames(x)
+
     uNames <-
       if (!is.null(usage))
         as.character(usage$Variable)
@@ -560,3 +563,10 @@ truncateText <- function(x) {
   paste(out, collapse = "\n")
 }
 
+check_names <- function(x) {
+  cn <- colnames(x)
+  if (is.null(cn)) {
+    stop("The data should have column names")
+  }
+  invisible(NULL)
+}

--- a/R/cubist.R
+++ b/R/cubist.R
@@ -78,7 +78,7 @@ cubist <-  function(x, ...) UseMethod("cubist")
 #' @aliases cubist cubist.default
 #' @param x a matrix or data frame of predictor variables. Missing
 #'  data are allowed but (at this time) only numeric, character and
-#'  factor values are allowed.
+#'  factor values are allowed. Must have column names.
 #' @param y a numeric vector of outcome
 #' @param committees an integer: how many committee models (e.g..
 #'  boosting iterations) should be used?

--- a/R/makeNamesFile.R
+++ b/R/makeNamesFile.R
@@ -51,6 +51,7 @@ makeNamesFile <-
       x <- as.data.frame(x)
     }
     # See issue #5
+    check_names(x)
     has_sample <- grep("^sample", colnames(x))
     if(length(has_sample))
       colnames(x) <- gsub("^sample", "__Sample", colnames(x))

--- a/R/predict.cubist.R
+++ b/R/predict.cubist.R
@@ -1,11 +1,11 @@
 #' Predict method for cubist fits
-#' 
-#' 
+#'
+#'
 #'Prediction using the parametric model are calculated using the
 #'  method of Quinlan (1992). If `neighbors` is greater than zero,
 #'  these predictions are adjusted by training set instances nearby
 #'  using the approach of Quinlan (1993).
-#' 
+#'
 #' @param object an object of class `cubist`
 #' @param newdata a data frame of predictors (in the same order as
 #'  the original training data)
@@ -16,57 +16,57 @@
 #' @return a numeric vector is returned
 #' @author R code by Max Kuhn, original C sources by R Quinlan and
 #'  modifications be Steve Weston
-#' @details Note that the predictions can fail for various reasons. 
+#' @details Note that the predictions can fail for various reasons.
 #'  For example, as shown in the examples, if the model uses a
 #'  qualitative predictor and the prediction data has a new level
-#'  of that predictor, the function will throw an error.  
+#'  of that predictor, the function will throw an error.
 #' @seealso [cubist()], [cubistControl()], [summary.cubist()],
 #'  [predict.cubist()], [dotplot.cubist()]
 #' @references Quinlan. Learning with continuous classes.
 #'  Proceedings of the 5th Australian Joint Conference On Artificial
 #'  Intelligence (1992) pp. 343-348
-#' 
+#'
 #' Quinlan. Combining instance-based and model-based learning.
 #'  Proceedings of the Tenth International Conference on Machine
 #'  Learning (1993) pp. 236-243
-#' 
+#'
 #' Quinlan. \strong{C4.5: Programs For Machine Learning} (1993)
 #'  Morgan Kaufmann Publishers Inc. San Francisco, CA
-#' 
+#'
 #' \url{http://rulequest.com/cubist-info.html}
 #' @keywords models
 #' @examples
-#' 
+#'
 #' library(mlbench)
 #' data(BostonHousing)
-#' 
+#'
 #' ## 1 committee and no instance-based correction, so just an M5 fit:
 #' mod1 <- cubist(x = BostonHousing[, -14], y = BostonHousing$medv)
 #' predict(mod1, BostonHousing[1:4, -14])
-#' 
+#'
 #' ## now add instances
 #' predict(mod1, BostonHousing[1:4, -14], neighbors = 5)
-#' 
-#' # Example error 
+#'
+#' # Example error
 #' iris_test <- iris
 #' iris_test$Species <- as.character(iris_test$Species)
-#' 
-#' mod <- cubist(x = iris_test[1:99, 2:5], 
+#'
+#' mod <- cubist(x = iris_test[1:99, 2:5],
 #'               y = iris_test$Sepal.Length[1:99])
-#'               
+#'
 #' # predict(mod, iris_test[100:151, 2:5])
-#' # Error: 
+#' # Error:
 #' # *** line 2 of `undefined.cases':
 #' # bad value of 'virginica' for attribute 'Species'
-#' @method predict cubist 
-#' @export 
+#' @method predict cubist
+#' @export
 predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
   if (is.null(newdata))
     stop("newdata must be non-null", call. = FALSE)
-  
+
   ## check order of data to make sure that it is the same
   newdata <- newdata[, object$vars$all, drop = FALSE]
-  
+
   if (length(neighbors) > 1)
     stop("only a single value of neighbors is allowed")
   if (neighbors > 9)
@@ -85,18 +85,19 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
       object$model
     )
   }
-  
+
   ## If there are case weights used during training, the C code
-  ## will expect a column of weights in the new data but the 
-  ## values will be ignored. `makeDataFile` puts those last in 
-  ## the data when `cubist.default` is run, so we will add a 
+  ## will expect a column of weights in the new data but the
+  ## values will be ignored. `makeDataFile` puts those last in
+  ## the data when `cubist.default` is run, so we will add a
   ## column of NA values at the end here
   if (object$caseWeights)
     newdata$case_weight_pred <- NA
-  
+
   ## make cases file
+  check_names(newdata)
   caseString <- makeDataFile(x = newdata, y = NULL)
-  
+
   ## fix breaking predictions when using sample parameter
   caseModel <- ifelse(!(regexpr("sample", object$model) == -1),
                       paste0(
@@ -109,19 +110,19 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
                         )
                       ),
                       object$model)
-  
+
   Z <- .C("predictions",
           as.character(caseString),
           as.character(object$names),
           as.character(object$data),
           as.character(caseModel),
-          pred = double(nrow(newdata)),    
+          pred = double(nrow(newdata)),
           output = character(1),
           PACKAGE = "Cubist")
   Z$pred
 }
 
-# There are occations when a new sample is predicted that has a 
+# There are occations when a new sample is predicted that has a
 # different categoriucal value than what was in the training set.
 # The C code does nto return a status integer and only issues
 # errors in Z$output so we parse that and set these cases to NA

--- a/R/predict.cubist.R
+++ b/R/predict.cubist.R
@@ -8,7 +8,7 @@
 #'
 #' @param object an object of class `cubist`
 #' @param newdata a data frame of predictors (in the same order as
-#'  the original training data)
+#'  the original training data). Must have column names.
 #' @param neighbors an integer from 0 to 9: how many instances to
 #'  use to correct the rule-based prediction?
 #' @param \dots other options to pass through the function (not
@@ -65,6 +65,7 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
     stop("newdata must be non-null", call. = FALSE)
 
   ## check order of data to make sure that it is the same
+  check_names(newdata)
   newdata <- newdata[, object$vars$all, drop = FALSE]
 
   if (length(neighbors) > 1)
@@ -95,7 +96,6 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
     newdata$case_weight_pred <- NA
 
   ## make cases file
-  check_names(newdata)
   caseString <- makeDataFile(x = newdata, y = NULL)
 
   ## fix breaking predictions when using sample parameter

--- a/man/cubist.default.Rd
+++ b/man/cubist.default.Rd
@@ -10,7 +10,7 @@
 \arguments{
 \item{x}{a matrix or data frame of predictor variables. Missing
 data are allowed but (at this time) only numeric, character and
-factor values are allowed.}
+factor values are allowed. Must have column names.}
 
 \item{y}{a numeric vector of outcome}
 

--- a/man/predict.cubist.Rd
+++ b/man/predict.cubist.Rd
@@ -10,7 +10,7 @@
 \item{object}{an object of class \code{cubist}}
 
 \item{newdata}{a data frame of predictors (in the same order as
-the original training data)}
+the original training data). Must have column names.}
 
 \item{neighbors}{an integer from 0 to 9: how many instances to
 use to correct the rule-based prediction?}
@@ -45,15 +45,15 @@ predict(mod1, BostonHousing[1:4, -14])
 ## now add instances
 predict(mod1, BostonHousing[1:4, -14], neighbors = 5)
 
-# Example error 
+# Example error
 iris_test <- iris
 iris_test$Species <- as.character(iris_test$Species)
 
-mod <- cubist(x = iris_test[1:99, 2:5], 
+mod <- cubist(x = iris_test[1:99, 2:5],
               y = iris_test$Sepal.Length[1:99])
-              
+
 # predict(mod, iris_test[100:151, 2:5])
-# Error: 
+# Error:
 # *** line 2 of `undefined.cases':
 # bad value of 'virginica' for attribute 'Species'
 }


### PR DESCRIPTION
Closes #24 

Before this change, column names would be added at fit time. That's not the best idea so now it errors and fit and prediction time: 

``` r
library(Cubist)
#> Loading required package: lattice

dt = mtcars
Z = dt[, 4]
X = dt[, 6]
X1 = dt[, 7]

T = cbind(dt[, 6], dt[, 7])

mod <- cubist(x=T, y=Z, committees=10)
#> Error in check_names(x): The data should have column names

T2 <- T
colnames(T2) <- letters[1:2]
mod <- cubist(x=T2, y=Z, committees=10)

predict(mod, T)
#> Error in check_names(newdata): The data should have column names
```

<sup>Created on 2021-05-05 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9000)</sup>