### PR TITLE
Force building on Windows i386

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,3 +32,4 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1.9001
 VignetteBuilder: knitr
 Encoding: UTF-8
+Biarch: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Cubist
 Type: Package
 Title: Rule- And Instance-Based Regression Modeling
-Version: 0.2.40
+Version: 0.2.40.9000
 Authors@R: c(
     person("Max", "Kuhn", , "mxkuhn@gmail.com", c("aut", "cre")),
     person("Steve", "Weston", role = "ctb"),


### PR DESCRIPTION
Closes #25 

Because you have a `configure.win` file, R will only attempt to build Cubist for the "main" architecture, which is x64. You can see that in your CI here
https://github.com/topepo/Cubist/runs/2548730360?check_suite_focus=true#step:10:83

This causes other packages that use Cubist to fail on CI, since most of the time those packages automatically try to build on both i386 and x64, but Cubist won't be available on the former. This also applies to C5.0, which is causing censored to fail here
https://github.com/tidymodels/censored/pull/57/checks?check_run_id=2602870628#step:10:101

The fix is to force R to build for both architectures with `Biarch: true`

This line confirms that it is building on i386 now https://github.com/topepo/Cubist/runs/2604513985?check_suite_focus=true#step:10:189