### PR TITLE
Composite option, dataString compression, and correct splits percentage

### DIFF
--- a/R/cubist.R
+++ b/R/cubist.R
@@ -20,7 +20,7 @@ cubist <-  function(x, ...) UseMethod("cubist")
 #  strings that mimic the formats that one would use with the
 #  command line version and get back the textual representation
 #  that would be saved to the .model file also as a string. The
-#  predicton function would then pass the model text string (and
+#  prediction function would then pass the model text string (and
 #  the data text string if instances are used) to the C code for
 #  prediction.
 
@@ -183,8 +183,8 @@ cubist.default <- function(x, y,
           as.character(namesString),
           as.character(dataString),
           as.logical(control$unbiased),     # -u : generate unbiased rules
-          "yes",                            # -i and -a : how to combine these?
-          as.integer(1),                    # -n : set the number of nearest neighbors (1 to 9)
+          control$composite,                # -i and -a : use/not rules or auto
+          as.integer(control$neighbors),    # -n : set the number of nearest neighbors (1 to 9)
           as.integer(committees),           # -c : construct a committee model
           as.double(control$sample),        # -S : use a sample of x% for training
                                             #      and a disjoint sample for testing
@@ -203,25 +203,45 @@ cubist.default <- function(x, y,
     Z$model <- gsub("__Sample", "sample", Z$model)
   }
 
+
+  if (grepl("Recommend using rules only", Z$output, fixed = TRUE)){
+    cat("Cubist recommends using rules only (i.e. set composite=False)\n")
+  }
+
+  # compress dataString and namesString so they hold less memory, also discard
+  # the datastring if we're not using instance-based correction
+  if (!(
+    (control$composite == "yes") |
+    (control$neighbors > 0) |
+    grepl("nearest neighbors", Z$output, fixed = TRUE))){
+    dataString <- ""
+  }
+
+  namesString <- memCompress(charToRaw(namesString), type = "b")
+  dataString <- memCompress(charToRaw(dataString), type = "b")
+
   splits <- getSplits(Z$model)
   if (!is.null(splits)) {
     splits$percentile <- NA
     for (i in 1:nrow(splits)) {
       if (!is.na(splits$value[i]))
-        splits$percentile[i] <-
-          sum(x[, as.character(splits$variable[i])] <= splits$value[i]) / nrow(x)
+        if (splits$value[i] != ""){
+          comparison_op <- operators(splits$dir[i])
+          splits$percentile[i] <-
+            sum(comparison_op(x[, as.character(splits$variable[i])], splits$value[i])) / nrow(x)
+        }
     }
   }
 
-  tmp <- strsplit(Z$model, "\\n")[[1]]
-  tmp <- tmp[grep("maxd", tmp)]
-  tmp <- strsplit(tmp, "\"")[[1]]
-  maxd <- tmp[grep("maxd", tmp) + 1]
-  Z$model <-
-    gsub(paste("insts=\"1\" nn=\"1\" ", "maxd=\"", maxd, "\"", sep = ""),
-         "insts=\"0\"",
-         Z$model)
-  maxd <- as.double(maxd)
+  if (grepl("maxd", Z$model, fixed = TRUE)){
+    tmp <- strsplit(Z$model, "\\n")[[1]]
+    tmp <- tmp[grep("maxd", tmp)]
+    tmp <- strsplit(tmp, "\"")[[1]]
+    maxd <- tmp[grep("maxd", tmp) + 1]
+    maxd <- as.double(maxd)
+  } else {
+    maxd <- NA
+  }
 
   usage <- varUsage(Z$output)
   if (is.null(usage) || nrow(usage) < ncol(x)) {
@@ -278,14 +298,18 @@ cubist.default <- function(x, y,
 #'  \url{http://rulequest.com/cubist-unix.html}
 #'
 #' @param unbiased a logical: should unbiased rules be used?
+#' @param composite a logical (or `auto`): should a composite
+#'  model be used? (`auto` lets Cubist decide)
 #' @param rules an integer (or `NA`): define an explicit limit to
-#'  the number of rules used (`NA` let's Cubist decide).
+#'  the number of rules used (`NA` lets Cubist decide).
+#' @param neighbors an integer (or `NA`): set the number of nearest-
+#'  neighbors or instance-based correction (only applicable when
+#'  composite is set to TRUE or NA)
 #' @param extrapolation a number between 0 and 100: since Cubist
 #'  uses linear models, predictions can be outside of the outside of
 #'  the range seen the training set. This parameter controls how
 #'  much rule predictions are adjusted to be consistent with the
 #'  training set.
-
 #' @param sample a number between 0 and 99.9: this is the
 #'  percentage of the data set to be randomly selected for model
 #'  building (not for out-of-bag type evaluation).
@@ -316,12 +340,38 @@ cubist.default <- function(x, y,
 #' @export cubistControl
 cubistControl <- function(
   unbiased = FALSE,
+  composite = TRUE,
   rules = 100,
+  neighbors = NA,
   extrapolation = 100,
   sample = 0.0,
   seed = sample.int(4096, size=1) - 1L,
   label = "outcome"
 ) {
+
+  if (!is.na(neighbors)) {
+    if (composite == FALSE){
+      stop("neighbors should not be set when composite=FALSE")
+    } else if (length(neighbors) > 1) {
+      stop("only a single value of neighbors is allowed")
+    } else if (neighbors < 1 | neighbors > 9) {
+      stop("'neighbors' must be between 1 and 9")
+    }
+  } else {
+    if (isTRUE(composite)){
+      cat("Cubist will choose an appropriate value for neigbors as this parameter is not set\n")
+    }
+    neighbors = 0
+  }
+
+  if (!(composite %in% c(TRUE, FALSE, 'auto')))
+    stop("composite parameters must be TRUE, FALSE, or 'auto")
+  if (composite == TRUE){
+    composite = 'yes'
+  } else if (composite == FALSE){
+    composite = 'no'
+  }
+
   if (!is.na(rules) & (rules < 1 | rules > 1000000))
     stop("number of rules must be between 1 and 1000000", call. = FALSE)
   if (extrapolation < 0 | extrapolation > 100)
@@ -331,7 +381,9 @@ cubistControl <- function(
 
   list(
     unbiased = unbiased,
+    composite = composite,
     rules = rules,
+    neighbors = neighbors,
     extrapolation = extrapolation / 100,
     sample = sample / 100,
     label = label,

--- a/R/parseCubistModel.R
+++ b/R/parseCubistModel.R
@@ -1,6 +1,32 @@
 ## TODO:
 ## 3) R function to write R prediction function
 
+op_lt <- function(a, b){
+  return(a < b)
+}
+op_le <- function(a, b){
+  return(a <= b)
+}
+op_gt <- function(a, b){
+  return(a > b)
+}
+op_ge <- function(a, b){
+  return(a >= b)
+}
+op_eq <- function(a, b){
+  return(a == b)
+}
+
+ops_list = list(">"  = op_gt,
+                ">=" = op_ge,
+                "<"  = op_lt,
+                "<=" = op_le,
+                "==" = op_eq)
+
+operators <- function(x){
+  op_func <- ops_list[[x]]
+  return(op_func)
+}
 
 countRules <- function(x)
   {
@@ -67,7 +93,7 @@ getSplits <- function(x)
             condNum[i] <- cIdx
           }
       }
-    
+
     numCom <- sum(grepl("^rules=", x))
     rulesPerCom <- unlist(lapply(split(ruleNum, as.factor(comNum)), max))
     rulesPerCom <- rulesPerCom[rulesPerCom > 0]
@@ -75,7 +101,7 @@ getSplits <- function(x)
       names(rulesPerCom) <- paste("Com", 1:numCom)
 
     ## In object x, what element starts a new rule
-    isNewRule <- ifelse(grepl("^conds=", x), TRUE, FALSE)   
+    isNewRule <- ifelse(grepl("^conds=", x), TRUE, FALSE)
     splitVar <- rep("", length(x))
     splitVal <- rep(NA, length(x))
     splitCats <- rep("", length(x))
@@ -88,7 +114,7 @@ getSplits <- function(x)
     ## or
     ##
     ## type="2" att="nox" cut="0.66799998" result=">"
-    ##    
+    ##
     isType2 <- grepl("^type=\"2\"", x)
     if(any(isType2))
       {
@@ -97,7 +123,7 @@ getSplits <- function(x)
         splitDir[isType2] <- type2(x[isType2])$rslt
         splitVal[isType2] <- type2(x[isType2])$val
       }
-    ## This is a split of categorical data such as 
+    ## This is a split of categorical data such as
     ##
     ##   X4 in {c, d}
     ##
@@ -124,7 +150,7 @@ getSplits <- function(x)
                             category = splitCats)
     splitData$type <- ""
     if(any(isType2)) splitData$type[isType2] <- "type2"
-    if(any(isType3)) splitData$type[isType3] <- "type3"    
+    if(any(isType3)) splitData$type[isType3] <- "type3"
     splitData <- splitData[splitData$variable != "" ,]
     splitData
   }
@@ -132,7 +158,7 @@ getSplits <- function(x)
 ## This function is no longer used
 printCubistRules <- function(x, dig = max(3, getOption("digits") - 5))
   {
-    
+
     comNum <- ruleNum <- condNum <- rep(NA, length(x))
     comIdx <- rIdx <- 0
     for(i in seq(along = x))
@@ -156,7 +182,7 @@ printCubistRules <- function(x, dig = max(3, getOption("digits") - 5))
             condNum[i] <- cIdx
           }
       }
-    
+
     numCom <- sum(grepl("^rules=", x))
     rulesPerCom <- unlist(lapply(split(ruleNum, as.factor(comNum)), max))
     rulesPerCom <- rulesPerCom[rulesPerCom > 0]
@@ -164,10 +190,10 @@ printCubistRules <- function(x, dig = max(3, getOption("digits") - 5))
     cat("Number of committees:", numCom, "\n")
     cat("Number of rules per committees:",
         paste(rulesPerCom, collapse = ", "), "\n\n")
-   
+
     isNewRule <- ifelse(grepl("^conds=", x), TRUE, FALSE)
-    isEqn <- ifelse(grepl("^coeff=", x), TRUE, FALSE) 
-    
+    isEqn <- ifelse(grepl("^coeff=", x), TRUE, FALSE)
+
     cond <- rep("", length(x))
     isType2 <- grepl("^type=\"2\"", x)
     if(any(isType2)) cond[isType2] <- type2(x[isType2], dig = dig)$text
@@ -182,7 +208,7 @@ printCubistRules <- function(x, dig = max(3, getOption("digits") - 5))
     tmp <- parser(tmp)
     ruleN <- rep(NA, length(x))
     ruleN[isNewRule] <- as.numeric(unlist(lapply(tmp, function(x) x["cover"])))
-    
+
     for(i in seq(along = x))
       {
         if(isNewRule[i])
@@ -211,10 +237,10 @@ type3 <- function(x)
     var <- substring(x, aInd + 4, eInd - 2)
     val <- substring(x, eInd + 5)
     multVals <- grepl(",", val)
-    val <- gsub(",", ", ", val) 
+    val <- gsub(",", ", ", val)
     val <- ifelse(multVals, paste("{", val, "}", sep = ""), val)
     txt <- ifelse(multVals,  paste(var, "in", val),  paste(var, "=", val))
- 
+
     list(var = var, val = val, text = txt)
   }
 
@@ -227,18 +253,18 @@ type2 <- function(x, dig = 3)
     vInd <- regexpr("val=", x)
 
     var <- val <- rslt <- rep("", length(x))
-    
+
     missingRule <- cInd < 1 & vInd > 0
-    
+
     if(any(missingRule))
       {
         var[missingRule] <- substring(x[missingRule], aInd[missingRule] + 4, vInd[missingRule] - 2)
         val[missingRule] <- "NA"
-        rslt[missingRule] <- "="  
+        rslt[missingRule] <- "="
       }
     if(any(!missingRule))
       {
-        var[!missingRule] <- substring(x[!missingRule], aInd[!missingRule] + 4, cInd[!missingRule] - 2)        
+        var[!missingRule] <- substring(x[!missingRule], aInd[!missingRule] + 4, cInd[!missingRule] - 2)
         val[!missingRule] <- substring(x[!missingRule], cInd[!missingRule] + 4, rInd[!missingRule] - 1)
         val[!missingRule] <- format(as.numeric(val[!missingRule]), digits = dig)
         rslt[!missingRule] <- substring(x[!missingRule], rInd[!missingRule] + 7)
@@ -260,13 +286,13 @@ eqn <- function(x, dig = 10, text = TRUE, varNames = NULL)
         p <- (length(starts) - 1)/2
         vars <- vector(mode = "numeric", length = p + 1)
         tmp <- vector(mode = "character", length = length(starts))
-        
+
         for(i in seq(along = starts))
           {
             if(i < length(starts))
               {
                 txt <- substring(x[j], starts[i], starts[i + 1] - 2)
-                
+
               } else txt <- substring(x[j], starts[i])
             tmp[i] <- gsub("(coeff=)|(att=)", "", txt)
           }
@@ -294,10 +320,10 @@ eqn <- function(x, dig = 10, text = TRUE, varNames = NULL)
                                    paste("+", format(vals[i], digits = dig)))
                     txt <- paste(txt, tmp2, nms[i-1])
                   }
-              }        
+              }
             out[j] <- txt
           } else {
-            
+
             nms <- c("(Intercept)", nms)
             names(vals) <- nms
             if(!is.null(varNames))
@@ -307,7 +333,7 @@ eqn <- function(x, dig = 10, text = TRUE, varNames = NULL)
                 #cat("j", j, "\tcoefs:", length(vals), "\tother:", length(vars2))
                 vals2 <- rep(NA, length(vars2))
                 names(vals2) <- vars2
-                vals <- c(vals, vals2)               
+                vals <- c(vals, vals2)
                 newNames <- c("(Intercept)", varNames)
                 vals <- vals[newNames]
               }
@@ -315,7 +341,7 @@ eqn <- function(x, dig = 10, text = TRUE, varNames = NULL)
             out[[j]] <- vals
 
           }
-        
+
       }
     out
   }
@@ -360,7 +386,7 @@ coef.cubist <- function(object, varNames = NULL, ...)  {
     }
   }
   isEqn <- ifelse(grepl("^coeff=", x), TRUE, FALSE)
-  
+
   isEqn <- grepl("^coeff=", x)
   coefs <-
     eqn(x[isEqn],
@@ -369,7 +395,7 @@ coef.cubist <- function(object, varNames = NULL, ...)  {
         varNames = varNames)
   p <- length(coefs)
   dims <- unlist(lapply(coefs, length))
-  
+
   coefs <- do.call("c", coefs)
   coms <- rep(comNum[isEqn], dims)
   rls <- rep(ruleNum[isEqn], dims)
@@ -393,6 +419,6 @@ coef.cubist <- function(object, varNames = NULL, ...)  {
   out$rule <- unlist(lapply(tmp, function(x) x[2]))
   out$tmp <- NULL
   out
-  
+
 }
 

--- a/R/predict.cubist.R
+++ b/R/predict.cubist.R
@@ -2,15 +2,11 @@
 #'
 #'
 #'Prediction using the parametric model are calculated using the
-#'  method of Quinlan (1992). If `neighbors` is greater than zero,
-#'  these predictions are adjusted by training set instances nearby
-#'  using the approach of Quinlan (1993).
+#'  method of Quinlan (1992).
 #'
 #' @param object an object of class `cubist`
 #' @param newdata a data frame of predictors (in the same order as
 #'  the original training data). Must have column names.
-#' @param neighbors an integer from 0 to 9: how many instances to
-#'  use to correct the rule-based prediction?
 #' @param \dots other options to pass through the function (not
 #'  currently used)
 #' @return a numeric vector is returned
@@ -45,7 +41,7 @@
 #' predict(mod1, BostonHousing[1:4, -14])
 #'
 #' ## now add instances
-#' predict(mod1, BostonHousing[1:4, -14], neighbors = 5)
+#' predict(mod1, BostonHousing[1:4, -14])
 #'
 #' # Example error
 #' iris_test <- iris
@@ -60,32 +56,13 @@
 #' # bad value of 'virginica' for attribute 'Species'
 #' @method predict cubist
 #' @export
-predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
+predict.cubist <- function (object, newdata = NULL, ...) {
   if (is.null(newdata))
     stop("newdata must be non-null", call. = FALSE)
 
   ## check order of data to make sure that it is the same
   check_names(newdata)
   newdata <- newdata[, object$vars$all, drop = FALSE]
-
-  if (length(neighbors) > 1)
-    stop("only a single value of neighbors is allowed")
-  if (neighbors > 9)
-    stop("'neighbors' must be less than 10")
-  if (neighbors > 0) {
-    object$model <- gsub(
-      "insts=\"0\"",
-      paste(
-        "insts=\"1\" nn=\"",
-        neighbors,
-        "\" maxd=\"",
-        object$maxd,
-        "\"",
-        sep = ""
-      ),
-      object$model
-    )
-  }
 
   ## If there are case weights used during training, the C code
   ## will expect a column of weights in the new data but the
@@ -111,10 +88,14 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
                       ),
                       object$model)
 
+  # decompress stored namesString and dataString
+  namesString <- rawToChar(memDecompress(object$names, type = "b"))
+  dataString <- rawToChar(memDecompress(object$data, type = "b"))
+
   Z <- .C("predictions",
           as.character(caseString),
-          as.character(object$names),
-          as.character(object$data),
+          as.character(namesString),
+          as.character(dataString),
           as.character(caseModel),
           pred = double(nrow(newdata)),
           output = character(1),
@@ -123,7 +104,7 @@ predict.cubist <- function (object, newdata = NULL, neighbors = 0, ...) {
 }
 
 # There are occations when a new sample is predicted that has a
-# different categoriucal value than what was in the training set.
+# different categorical value than what was in the training set.
 # The C code does nto return a status integer and only issues
 # errors in Z$output so we parse that and set these cases to NA
 

--- a/man/cubistControl.Rd
+++ b/man/cubistControl.Rd
@@ -6,7 +6,9 @@
 \usage{
 cubistControl(
   unbiased = FALSE,
+  composite = TRUE,
   rules = 100,
+  neighbors = NA,
   extrapolation = 100,
   sample = 0,
   seed = sample.int(4096, size = 1) - 1L,
@@ -16,8 +18,15 @@ cubistControl(
 \arguments{
 \item{unbiased}{a logical: should unbiased rules be used?}
 
+\item{composite}{a logical (or \code{auto}): should a composite
+model be used? (\code{auto} lets Cubist decide)}
+
 \item{rules}{an integer (or \code{NA}): define an explicit limit to
-the number of rules used (\code{NA} let's Cubist decide).}
+the number of rules used (\code{NA} lets Cubist decide).}
+
+\item{neighbors}{an integer (or \code{NA}): set the number of nearest-
+neighbors or instance-based correction (only applicable when
+composite is set to TRUE or NA)}
 
 \item{extrapolation}{a number between 0 and 100: since Cubist
 uses linear models, predictions can be outside of the outside of

--- a/man/predict.cubist.Rd
+++ b/man/predict.cubist.Rd
@@ -4,16 +4,13 @@
 \alias{predict.cubist}
 \title{Predict method for cubist fits}
 \usage{
-\method{predict}{cubist}(object, newdata = NULL, neighbors = 0, ...)
+\method{predict}{cubist}(object, newdata = NULL, ...)
 }
 \arguments{
 \item{object}{an object of class \code{cubist}}
 
 \item{newdata}{a data frame of predictors (in the same order as
 the original training data). Must have column names.}
-
-\item{neighbors}{an integer from 0 to 9: how many instances to
-use to correct the rule-based prediction?}
 
 \item{\dots}{other options to pass through the function (not
 currently used)}
@@ -23,9 +20,7 @@ a numeric vector is returned
 }
 \description{
 Prediction using the parametric model are calculated using the
-method of Quinlan (1992). If \code{neighbors} is greater than zero,
-these predictions are adjusted by training set instances nearby
-using the approach of Quinlan (1993).
+method of Quinlan (1992).
 }
 \details{
 Note that the predictions can fail for various reasons.
@@ -43,7 +38,7 @@ mod1 <- cubist(x = BostonHousing[, -14], y = BostonHousing$medv)
 predict(mod1, BostonHousing[1:4, -14])
 
 ## now add instances
-predict(mod1, BostonHousing[1:4, -14], neighbors = 5)
+predict(mod1, BostonHousing[1:4, -14])
 
 # Example error
 iris_test <- iris

--- a/vignettes/cubist.Rmd
+++ b/vignettes/cubist.Rmd
@@ -95,29 +95,10 @@ cor(com_pred, test_resp)^2
 
 ## Instance-Based Corrections
 
-Another innovation in Cubist using nearest-neighbors to adjust the predictions from the rule-based model. First, a model tree (with or without committees) is created. Once a sample is predicted by this model, Cubist can find it's nearest neighbors and determine the average of these training set points. See Quinlan (1993a) for the details of the adjustment as well as [this blog post](https://rviews.rstudio.com/2020/05/21/modern-rule-based-models).
+Another innovation in Cubist is using nearest-neighbors to adjust the predictions from the rule-based model. First, a model tree (with or without committees) is created. Once a sample is predicted by this model, Cubist can find it's nearest neighbors and determine the average of these training set points. See Quinlan (1993a) for the details of the adjustment as well as [this blog post](https://rviews.rstudio.com/2020/05/21/modern-rule-based-models).
 
-The development of rules and committees is independent of the choice of using instances. The original `C` code allowed the program to choose whether to use instances, not use them or let the program decide. Our approach is to build a model with the `cubist()` function that is ignorant to the decision about instances. When samples are predicted, the argument `neighbors` can be used to adjust the rule-based model predictions (or not). 
+The development of rules and committees is independent of the choice of using instances. The choice of whether to use instance-based correction is determined by the `composite` argument, which is TRUE to force Cubist to use instances, FALSE to only use rule-based models, and 'auto' to let Cubist decide whether to include instances. When samples are predicted, the argument `neighbors` can be used to adjust the rule-based model predictions (or not) by setting the parameter to a value in the range of 0 to 9 neighbors. Note that this introduces slight opacity in the prediction process as the linear regressors are no longer perfectly followed.
 
-We can add instances to the previously fit committee model:
-
-```{r bh6}
-inst_pred <- predict(com_model, test_pred, neighbors = 5)
-## RMSE
-sqrt(mean((inst_pred - test_resp)^2))
-## R^2
-cor(inst_pred, test_resp)^2
-``` 
-
-Note that the previous models used the implicit default of `neighbors = 0` for their predictions.
-
-It may also be useful to see how the different models fit a single predictor. Here is the test set data for a model with one predictor (`Gr_Liv_Area`), 100 committees, and various values of `neighbors`: 
-
-```{r echo = FALSE, fig.align='center'}
-knitr::include_graphics("neighbors.gif")
-```
-
-After the initial use of the instance-based correction, there is very little change in the mainstream of the data. 
 
 ## Model tuning
 


### PR DESCRIPTION
Hi @topepo! I've been working on a port of your code into Python as I believe Kirk mentioned over here: https://github.com/pjaselin/Cubist. Thank you so much for all the work you are your colleagues have done on this!

Some improvements/fixes I've made here:
- Composite option: in one parameter you can choose whether to use instance-based correction or let Cubist decide. I think this is helpful because instance-based correction adds a little opacity to the prediction process.
-  Moved number of nearest neighbors to cubistControl: I understand your intent was to change the number of neighbors at predict time since that's where it comes into use but I wonder if it makes more sense to be part of training as it is used in model evaluation.
- dataString compression: I have the dataString compressed so the model has a smaller memory footprint when using instance-based correction.
- Correct splits percentage: I noticed that you had hardcoded "<=" at https://github.com/topepo/Cubist/blob/548ccd7b75b97e7f263c750c2bdeaa5e4a4c2e5e/R/cubist.R#L212
so I came up with a way to get the right comparison operator based on the model. (This is probably the one definite fix here)

Let me know if you'd like to break this apart and I'd be happy to take feedback!