### PR TITLE
Provide correct argument for `ht_destroy()`

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -12,7 +12,7 @@ extern unsigned int ht_hashcode(const char *key);
 
 /* Constructor and destructor */
 extern void *ht_new(int size);
-extern void ht_destroy();
+extern void ht_destroy(void *ht);
 
 /* Hash table iteration functions */
 extern void *ht_next(void *ht);


### PR DESCRIPTION
I was able to reproduce the warnings through Docker with Gabor's clang15 dockerfile https://gist.github.com/gaborcsardi/04e1ed3c74dc391914409c546d9d53ef

@topepo all you need to do is apply this exact same patch to C5.0, it was much simpler than I thought, I got a bit mixed up during our live attempt to fix it yesterday. 

Before (note the warnings about `-Wstrict-prototypes` and `-Wdeprecated-non-prototype`):

<details>

```
> devtools::load_all()
i Loading Cubist
Re-compiling Cubist
-  installing *source* package 'Cubist' ...
   ** using staged installation
   checking for gcc... gcc
   checking whether the C compiler works... yes
   checking for C compiler default output file name... a.out
   checking for suffix of executables... 
   checking whether we are cross compiling... no
   checking for suffix of object files... o
   checking whether we are using the GNU C compiler... yes
   checking whether gcc accepts -g... yes
   checking for gcc option to accept ISO C89... none needed
   configure: creating ./config.status
   config.status: creating src/Makevars
   ** libs
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c construct.c -o construct.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c contin.c -o contin.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c discr.c -o discr.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c formrules.c -o formrules.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c formtree.c -o formtree.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c getdata.c -o getdata.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c getnames.c -o getnames.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c global.c -o global.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c hash.c -o hash.o
   In file included from hash.c:5:
   ./hash.h:15:23: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   extern void ht_destroy();
                         ^
                          void
   ./hash.h:15:13: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
   extern void ht_destroy();
               ^
   hash.c:72:6: note: conflicting prototype is here
   void ht_destroy(void *ht) {
        ^
   2 warnings generated.
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c implicitatt.c -o implicitatt.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c instance.c -o instance.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c modelfiles.c -o modelfiles.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c predict.c -o predict.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c prunetree.c -o prunetree.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rcubist.c -o rcubist.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c redefine.c -o redefine.o
   In file included from redefine.c:19:
   ./hash.h:15:23: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
   extern void ht_destroy();
                         ^
                          void
   redefine.c:209:15: warning: passing arguments to 'ht_destroy' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
       ht_destroy(strbufv);
                 ^
   2 warnings generated.
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c regress.c -o regress.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rsample.c -o rsample.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rulebasedmodels.c -o rulebasedmodels.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rules.c -o rules.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c sample.c -o sample.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c sort.c -o sort.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c stats.c -o stats.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c strbuf.c -o strbuf.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c top.c -o top.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c trees.c -o trees.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c update.c -o update.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c utility.c -o utility.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c xval.c -o xval.o
   clang -shared -L/opt/R/devel/lib/R/lib -L/usr/local/lib -o Cubist.so construct.o contin.o discr.o formrules.o formtree.o getdata.o getnames.o global.o hash.o implicitatt.o instance.o modelfiles.o predict.o prunetree.o rcubist.o redefine.o regress.o rsample.o rulebasedmodels.o rules.o sample.o sort.o stats.o strbuf.o top.o trees.o update.o utility.o xval.o -L/opt/R/devel/lib/R/lib -lR
   installing to /tmp/RtmpEdgCwI/devtools_install_f8aa2bc51024/00LOCK-Cubist/00new/Cubist/libs
   ** checking absolute paths in shared objects and dynamic libraries
-  DONE (Cubist)
```

</details>

After:

<details>

```
> devtools::load_all()
i Loading Cubist
Re-compiling Cubist
-  installing *source* package 'Cubist' ...
   ** using staged installation
   checking for gcc... gcc
   checking whether the C compiler works... yes
   checking for C compiler default output file name... a.out
   checking for suffix of executables... 
   checking whether we are cross compiling... no
   checking for suffix of object files... o
   checking whether we are using the GNU C compiler... yes
   checking whether gcc accepts -g... yes
   checking for gcc option to accept ISO C89... none needed
   configure: creating ./config.status
   config.status: creating src/Makevars
   ** libs
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c construct.c -o construct.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c contin.c -o contin.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c discr.c -o discr.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c formrules.c -o formrules.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c formtree.c -o formtree.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c getdata.c -o getdata.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c getnames.c -o getnames.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c global.c -o global.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c hash.c -o hash.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c implicitatt.c -o implicitatt.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c instance.c -o instance.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c modelfiles.c -o modelfiles.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c predict.c -o predict.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c prunetree.c -o prunetree.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rcubist.c -o rcubist.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c redefine.c -o redefine.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c regress.c -o regress.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rsample.c -o rsample.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rulebasedmodels.c -o rulebasedmodels.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c rules.c -o rules.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c sample.c -o sample.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c sort.c -o sort.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c stats.c -o stats.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c strbuf.c -o strbuf.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c top.c -o top.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c trees.c -o trees.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c update.c -o update.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c utility.c -o utility.o
   clang -I"/opt/R/devel/lib/R/include" -DNDEBUG -DNDEBUG  -I/usr/local/include   -g -fpic  -O2 -g -Wunneeded-internal-declaration -Winvalid-utf8 -Wformat -Wsizeof-pointer-div -Wliteral-conversion -Wempty-body -Wreturn-stack-address -Wnon-c-typedef-for-linkage -Wstrict-prototypes -c xval.c -o xval.o
   clang -shared -L/opt/R/devel/lib/R/lib -L/usr/local/lib -o Cubist.so construct.o contin.o discr.o formrules.o formtree.o getdata.o getnames.o global.o hash.o implicitatt.o instance.o modelfiles.o predict.o prunetree.o rcubist.o redefine.o regress.o rsample.o rulebasedmodels.o rules.o sample.o sort.o stats.o strbuf.o top.o trees.o update.o utility.o xval.o -L/opt/R/devel/lib/R/lib -lR
   installing to /tmp/RtmpEdgCwI/devtools_install_f8aa457d5ec9/00LOCK-Cubist/00new/Cubist/libs
   ** checking absolute paths in shared objects and dynamic libraries
-  DONE (Cubist)
```

</details>