### PR TITLE
Another tweak to the `snprintf()` size handling

### DIFF
--- a/src/utility.c
+++ b/src/utility.c
@@ -725,7 +725,7 @@ void CValToStr(ContValue CV, Attribute Att, String DS, size_t DS_size)
     DayToDate(floor(CV / 1440) + TSBase, DS, DS_size);
     DS[10] = ' ';
     Mins = rint(CV) - floor(CV / 1440) * 1440;
-    SecsToTime(Mins * 60, DS + 11, DS_size);
+    SecsToTime(Mins * 60, DS + 11, DS_size - 11);
   } else if (DateVal(Att)) {
     DayToDate(CV, DS, DS_size);
   } else if (TimeVal(Att)) {


### PR DESCRIPTION
Follow up to #49 

I looked over our `snprintf()` usage again and this is the only other place I could find that looks like it could be a problem. It is a similar patch to what is done in #49 (subtracting off the amount that we advanced the pointer forward by)