### PR TITLE
don't format splits outside of printing

### DIFF
--- a/R/parseCubistModel.R
+++ b/R/parseCubistModel.R
@@ -218,7 +218,7 @@ type3 <- function(x)
     list(var = var, val = val, text = txt)
   }
 
-type2 <- function(x, dig = 3)
+type2 <- function(x, dig = NULL)
   {
     x <- gsub("\"", "", x)
     aInd <- regexpr("att=", x)
@@ -240,7 +240,10 @@ type2 <- function(x, dig = 3)
       {
         var[!missingRule] <- substring(x[!missingRule], aInd[!missingRule] + 4, cInd[!missingRule] - 2)        
         val[!missingRule] <- substring(x[!missingRule], cInd[!missingRule] + 4, rInd[!missingRule] - 1)
-        val[!missingRule] <- format(as.numeric(val[!missingRule]), digits = dig)
+        val[!missingRule] <- as.numeric(val[!missingRule])
+        if (!is.null(dig)) {
+          val[!missingRule] <- format(val[!missingRule], digits = dig)
+        }
         rslt[!missingRule] <- substring(x[!missingRule], rInd[!missingRule] + 7)
       }
 


### PR DESCRIPTION
This change will not affect how model predictions will happen in this package. Instead it fixes how the data is stored in the model object. Specifically by not applying `format()` to data that is stored  in `$splits`. Consider the following model:

```r
library(tidypredict)
library(Cubist)

data("BostonHousing", package = "mlbench")

BostonHousing$chas <- as.numeric(BostonHousing$chas) - 1

set.seed(1)
inTrain <- sample(1:nrow(BostonHousing), floor(.8 * nrow(BostonHousing)))

train_pred <- BostonHousing[inTrain, -14]
test_pred <- BostonHousing[-inTrain, -14]

train_resp <- BostonHousing$medv[inTrain]
test_resp <- BostonHousing$medv[-inTrain]

com_model <- cubist(
  x = train_pred,
  y = train_resp,
  committees = 2,
  control = cubistControl(rules = 3)
)
```

If we imagine predicting on `train_pred[205, ]` we have the following data

```r
#>        crim zn indus chas   nox    rm age    dis rad tax ptratio      b lstat
#> 297 0.05372  0 13.92    0 0.437 6.549  51 5.9604   4 289      16 392.85  7.39
```

in particular note the `rm` value of `6.549`. Next consider the 3 rules of the 2nd committee. According to this, we would be in rule 2/2 or 2/3 depending on the `lstat`.

```r
#>   Rule 2/1:
#> 
#>     if
#>  rm <= 6.546
#>  lstat > 5.39
#> 
#>   Rule 2/2: 
#> 
#>     if
#>  rm > 6.546
#>  lstat > 5.39
#> 
#>   Rule 2/3:
#> 
#>     if
#>  lstat <= 5.39
```

Next lets take a look at the extracted thresholds in the `$splits` slot.

```r
com_model$splits
#>    committee rule variable dir value category  type percentile
#> 20         1    1    lstat   >  9.53          type2  0.4034653
#> 23         1    2    lstat  <=  9.53          type2  0.4034653
#> 24         1    2       rm  <=  6.23          type2  0.5148515
#> 27         1    3    lstat  <=  9.53          type2  0.4034653
#> 28         1    3       rm   >  6.23          type2  0.5148515
#> 32         2    1       rm  <=  6.55          type2  0.7103960
#> 33         2    1    lstat   >  5.39          type2  0.1608911
#> 36         2    2       rm   >  6.55          type2  0.7103960
#> 37         2    2    lstat   >  5.39          type2  0.1608911
#> 40         2    3    lstat  <=  5.39          type2  0.1608911
```

It lists the splitting threshold to be `6.55` instead of `6.546`, making it so this observation would rule rule 2/1 instead. This is happening because we are rounding the values of `splits$value`.

## Full reprex

<details>
<summary>Details</summary>

``` r
library(tidypredict)
library(Cubist)
#> Loading required package: lattice

data("BostonHousing", package = "mlbench")

BostonHousing$chas <- as.numeric(BostonHousing$chas) - 1

set.seed(1)
inTrain <- sample(1:nrow(BostonHousing), floor(.8 * nrow(BostonHousing)))

train_pred <- BostonHousing[inTrain, -14]
test_pred <- BostonHousing[-inTrain, -14]

train_resp <- BostonHousing$medv[inTrain]
test_resp <- BostonHousing$medv[-inTrain]

com_model <- cubist(
  x = train_pred,
  y = train_resp,
  committees = 2,
  control = cubistControl(rules = 3)
)

summary(com_model)
#> 
#> Call:
#> cubist.default(x = train_pred, y = train_resp, committees = 2, control
#>  = cubistControl(rules = 3))
#> 
#> 
#> Cubist [Release 2.07 GPL Edition]  Fri Oct 24 10:24:19 2025
#> ---------------------------------
#> 
#>     Target attribute `outcome'
#> 
#> Read 404 cases (14 attributes) from undefined.data
#> 
#> Model 1:
#> 
#>   Rule 1/1: [241 cases, mean 17.54, range 5 to 31, est err 2.33]
#> 
#>     if
#>  lstat > 9.53
#>     then
#>  outcome = 49.03 - 0.35 lstat - 0.86 dis - 0.74 ptratio - 12.9 nox
#>            - 0.03 age - 0.1 crim + 0.0057 b
#> 
#>   Rule 1/2: [29 cases, mean 25.08, range 18.2 to 50, est err 2.64]
#> 
#>     if
#>  rm <= 6.226
#>  lstat <= 9.53
#>     then
#>  outcome = -18.07 + 3.91 crim - 1.67 lstat + 0.0834 b + 3.3 rm
#> 
#>   Rule 1/3: [134 cases, mean 31.94, range 16.5 to 50, est err 2.66]
#> 
#>     if
#>  rm > 6.226
#>  lstat <= 9.53
#>     then
#>  outcome = -11.7 + 2.78 crim + 10 rm - 0.85 lstat - 0.0208 tax
#>            - 0.63 ptratio - 0.047 age - 0.6 dis
#> 
#> Model 2:
#> 
#>   Rule 2/1: [279 cases, mean 18.74, range 5 to 50, est err 2.52]
#> 
#>     if
#>  rm <= 6.546
#>  lstat > 5.39
#>     then
#>  outcome = 49.33 + 0.41 rad - 0.0199 tax - 0.32 lstat - 14.2 nox
#>            - 0.73 dis - 0.19 crim - 0.48 ptratio - 0.036 age + 0.11 indus
#> 
#>   Rule 2/2: [60 cases, mean 26.56, range 7.5 to 50, est err 3.10]
#> 
#>     if
#>  rm > 6.546
#>  lstat > 5.39
#>     then
#>  outcome = 15.78 - 0.0312 tax + 6 rm - 1 ptratio + 0.05 rad - 0.05 lstat
#>            - 0.1 dis - 1.7 nox + 0.0011 b - 0.01 crim
#> 
#>   Rule 2/3: [65 cases, mean 37.12, range 22.5 to 50, est err 3.79]
#> 
#>     if
#>  lstat <= 5.39
#>     then
#>  outcome = -31.16 + 5.03 crim + 9.7 rm - 0.0022 tax - 0.05 lstat
#>            + 0.04 rad - 0.12 ptratio - 0.11 dis - 1.4 nox + 0.0016 b
#> 
#> 
#> Evaluation on training data (404 cases):
#> 
#>     Average  |error|               2.21
#>     Relative |error|               0.32
#>     Correlation coefficient        0.95
#> 
#> 
#>  Attribute usage:
#>    Conds  Model
#> 
#>    100%   100%    lstat
#>     62%    36%    rm
#>           100%    crim
#>            96%    dis
#>            96%    ptratio
#>            81%    age
#>            80%    nox
#>            67%    tax
#>            50%    rad
#>            49%    b
#>            35%    indus
#> 
#> 
#> Time: 0.0 secs

com_model$splits
#>    committee rule variable dir value category  type percentile
#> 20         1    1    lstat   >  9.53          type2  0.4034653
#> 23         1    2    lstat  <=  9.53          type2  0.4034653
#> 24         1    2       rm  <=  6.23          type2  0.5148515
#> 27         1    3    lstat  <=  9.53          type2  0.4034653
#> 28         1    3       rm   >  6.23          type2  0.5148515
#> 32         2    1       rm  <=  6.55          type2  0.7103960
#> 33         2    1    lstat   >  5.39          type2  0.1608911
#> 36         2    2       rm   >  6.55          type2  0.7103960
#> 37         2    2    lstat   >  5.39          type2  0.1608911
#> 40         2    3    lstat  <=  5.39          type2  0.1608911

com_model$model
#> [1] "id=\"Cubist 2.07 GPL Edition 2025-10-24\"\nprec=\"1\" globalmean=\"22.8604\" extrap=\"1\" insts=\"0\" ceiling=\"95\" floor=\"0\"\natt=\"outcome\" mean=\"22.86\" sd=\"9.499031\" min=\"5\" max=\"50\"\natt=\"crim\" mean=\"3.470944\" sd=\"8.052082\" min=\"0.00632\" max=\"73.5341\"\natt=\"zn\" mean=\"11.37\" sd=\"23.26148\" min=\"0\" max=\"100\"\natt=\"indus\" mean=\"11.261\" sd=\"6.942586\" min=\"0.46\" max=\"27.74\"\natt=\"chas\" mean=\"0\" sd=\"0.2625155\" min=\"0\" max=\"1\"\natt=\"nox\" mean=\"0.55304\" sd=\"0.1153235\" min=\"0.385\" max=\"0.871\"\natt=\"rm\" mean=\"6.3027\" sd=\"0.7059205\" min=\"3.561\" max=\"8.725\"\natt=\"age\" mean=\"68.52\" sd=\"28.58532\" min=\"2.9\" max=\"100\"\natt=\"dis\" mean=\"3.78447\" sd=\"2.100122\" min=\"1.1296\" max=\"12.1265\"\natt=\"rad\" mean=\"9.6\" sd=\"8.755972\" min=\"1\" max=\"24\"\natt=\"tax\" mean=\"411.6\" sd=\"169.496\" min=\"187\" max=\"711\"\natt=\"ptratio\" mean=\"18.5\" sd=\"2.150986\" min=\"12.6\" max=\"22\"\natt=\"b\" mean=\"353.664\" sd=\"95.71353\" min=\"2.52\" max=\"396.9\"\natt=\"lstat\" mean=\"12.541\" sd=\"7.139946\" min=\"1.73\" max=\"37.97\"\nredn=\"0.945\" entries=\"2\"\nrules=\"3\"\nconds=\"1\" cover=\"241\" mean=\"17.54\" loval=\"5\" hival=\"31\" esterr=\"2.33\"\ntype=\"2\" att=\"lstat\" cut=\"9.5299997\" result=\">\"\ncoeff=\"49.03\" att=\"crim\" coeff=\"-0.1\" att=\"nox\" coeff=\"-12.9\" att=\"age\" coeff=\"-0.03\" att=\"dis\" coeff=\"-0.86\" att=\"ptratio\" coeff=\"-0.74\" att=\"b\" coeff=\"0.0057\" att=\"lstat\" coeff=\"-0.35\"\nconds=\"2\" cover=\"29\" mean=\"25.08\" loval=\"18.2\" hival=\"50\" esterr=\"2.64\"\ntype=\"2\" att=\"lstat\" cut=\"9.5299997\" result=\"<=\"\ntype=\"2\" att=\"rm\" cut=\"6.2259998\" result=\"<=\"\ncoeff=\"-18.07\" att=\"crim\" coeff=\"3.91\" att=\"rm\" coeff=\"3.3\" att=\"b\" coeff=\"0.0834\" att=\"lstat\" coeff=\"-1.67\"\nconds=\"2\" cover=\"134\" mean=\"31.94\" loval=\"16.5\" hival=\"50\" esterr=\"2.66\"\ntype=\"2\" att=\"lstat\" cut=\"9.5299997\" result=\"<=\"\ntype=\"2\" att=\"rm\" cut=\"6.2259998\" result=\">\"\ncoeff=\"-11.7\" att=\"crim\" coeff=\"2.78\" att=\"rm\" coeff=\"10\" att=\"age\" coeff=\"-0.047\" att=\"dis\" coeff=\"-0.6\" att=\"tax\" coeff=\"-0.0208\" att=\"ptratio\" coeff=\"-0.63\" att=\"lstat\" coeff=\"-0.85\"\nrules=\"3\"\nconds=\"2\" cover=\"279\" mean=\"18.74\" loval=\"5\" hival=\"50\" esterr=\"2.52\"\ntype=\"2\" att=\"rm\" cut=\"6.546\" result=\"<=\"\ntype=\"2\" att=\"lstat\" cut=\"5.3899999\" result=\">\"\ncoeff=\"49.33\" att=\"crim\" coeff=\"-0.19\" att=\"indus\" coeff=\"0.11\" att=\"nox\" coeff=\"-14.2\" att=\"age\" coeff=\"-0.036\" att=\"dis\" coeff=\"-0.73\" att=\"rad\" coeff=\"0.41\" att=\"tax\" coeff=\"-0.0199\" att=\"ptratio\" coeff=\"-0.48\" att=\"lstat\" coeff=\"-0.32\"\nconds=\"2\" cover=\"60\" mean=\"26.56\" loval=\"7.5\" hival=\"50\" esterr=\"3.10\"\ntype=\"2\" att=\"rm\" cut=\"6.546\" result=\">\"\ntype=\"2\" att=\"lstat\" cut=\"5.3899999\" result=\">\"\ncoeff=\"15.78\" att=\"crim\" coeff=\"-0.01\" att=\"nox\" coeff=\"-1.7\" att=\"rm\" coeff=\"6\" att=\"dis\" coeff=\"-0.1\" att=\"rad\" coeff=\"0.05\" att=\"tax\" coeff=\"-0.0312\" att=\"ptratio\" coeff=\"-1\" att=\"b\" coeff=\"0.0011\" att=\"lstat\" coeff=\"-0.05\"\nconds=\"1\" cover=\"65\" mean=\"37.12\" loval=\"22.5\" hival=\"50\" esterr=\"3.79\"\ntype=\"2\" att=\"lstat\" cut=\"5.3899999\" result=\"<=\"\ncoeff=\"-31.16\" att=\"crim\" coeff=\"5.03\" att=\"nox\" coeff=\"-1.4\" att=\"rm\" coeff=\"9.7\" att=\"dis\" coeff=\"-0.11\" att=\"rad\" coeff=\"0.04\" att=\"tax\" coeff=\"-0.0022\" att=\"ptratio\" coeff=\"-0.12\" att=\"b\" coeff=\"0.0016\" att=\"lstat\" coeff=\"-0.05\"\n"
```

<sup>Created on 2025-10-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

</details>
